### PR TITLE
Fixed issue #2, "Can't enter same letter twice in a row"

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -157,6 +157,7 @@ export const App = () => {
             gameHistory={gameHistory}
             gameStatus={gameStatus}
             mobileLetter={mobileLetter}
+            setMobileLetter={setMobileLetter}
             setGameStatus={setGameStatus}
             timer={timer}
             trackGameHistory={trackGameHistory}

--- a/client/src/components/MobileKeyboard/MobileKeyboard.tsx
+++ b/client/src/components/MobileKeyboard/MobileKeyboard.tsx
@@ -3,7 +3,6 @@
 /** @jsx jsx */
 import { css, jsx } from '@emotion/react';
 
-
 const enKeys = [
     ["Q","W","E","R","T","Y","U","I","O","P"],
     ["A","S","D","F","G","H","J","K","L"],
@@ -37,10 +36,6 @@ const key = css`
 `
 
 export const MobileKeyboard = ({ setMobileLetter }:any) => {
-    
-    const keyTap = (char:String) => {
-        setMobileLetter(char);
-    }
 
     return (
         <div css={keyboard}>
@@ -50,7 +45,7 @@ export const MobileKeyboard = ({ setMobileLetter }:any) => {
                         <div 
                             key={`charKey-${x}`} 
                             css={key}
-                            onClick={()=>keyTap(char)}
+                            onClick={()=>setMobileLetter(char)}
                         >
                             {char}
                         </div>)}

--- a/client/src/components/WordBoard/WordBoard.tsx
+++ b/client/src/components/WordBoard/WordBoard.tsx
@@ -8,7 +8,7 @@ import { alphabet, checkOutcome } from '../../tools';
 const dummyRowArray = [0,1,2,3,4];
 import fourDictionary from '../../assets/words/en-us/four/index.json';
 
-export const WordBoard = ({ _trackGameHistory, _gameHistory, gameStatus, mobileLetter, setGameStatus, timer, setTimer }:any) => {
+export const WordBoard = ({ _trackGameHistory, _gameHistory, gameStatus, mobileLetter, setMobileLetter, setGameStatus, timer, setTimer }:any) => {
     
     const [possibleOutcomes, setPossibleOutcomes] = useState<any>([]);
     const [currentWord, setCurrentWord] = useState<any>([]);
@@ -81,11 +81,11 @@ export const WordBoard = ({ _trackGameHistory, _gameHistory, gameStatus, mobileL
         let letter;
         if(fromMobile) {
             letter = mobileLetter;
-            setActiveLetter(letter)
+            setMobileLetter("");
         } else {
             letter = event.key.toUpperCase();
-            if(alphabet.includes(letter)) setActiveLetter(letter);
         }
+        if(alphabet.includes(letter)) setActiveLetter(letter);
     }
 
     useEffect(() => {
@@ -109,7 +109,7 @@ export const WordBoard = ({ _trackGameHistory, _gameHistory, gameStatus, mobileL
 
     useEffect(()=>{
         // Detect Entry via MobileKeyboard
-        charSelect(mobileLetter,true);
+        charSelect(mobileLetter,true)
     },[mobileLetter])
 
     useEffect(() => {
@@ -142,18 +142,6 @@ export const WordBoard = ({ _trackGameHistory, _gameHistory, gameStatus, mobileL
             });
         }
     },[currentWord,possibleOutcomes,activeLetter,gameStatus]);
-
-    // useEffect(()=>{
-    //     if(activeLetter) {
-    //         let myClone = [...currentWord.at(-1)];
-    //         if((guessState==="active"&&myClone.indexOf(""))) {
-    //             myClone[myClone.indexOf("")] = activeLetter;
-    //         }
-    //         console.log("TEST: ",activeLetter,guessState,myClone);
-    //     }
-    //     //setRoundMoves(current => [...current, {letter: activeLetter, row: currentWord.length-1, guess: currentWord.at(-1).join(""), result: guessState, timestamp: Date.now()}]);
-    // },[activeLetter,guessState,currentWord]);
-
 
     useEffect(() => {
         if(!gameStatus.paused) {

--- a/client/src/tools/index.ts
+++ b/client/src/tools/index.ts
@@ -22,6 +22,8 @@ export const checkOutcome = (i:number,isNew:boolean,passWord:string) => {
     let word:string;
     if(isNew) {
         word = getWord();
+        //TEST MODE
+        //word = "FEAT"; // feat >> beat >> boat >> boot >> book (check double letter)
         matches = [];
     } else {
         word = passWord;


### PR DESCRIPTION
Was strictly a `mobileKeyboard` issue owing to the `mobileLetter` state object not triggering re-render when same letter is tapped twice. Solved by resetting `mobileLetter` to empty string after logging.